### PR TITLE
fix: add R6 to Imports in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: This package calculates prevalence of a condition in a population.
 License: Apache License
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends: 
     R (>= 4.1.0)
 Imports: 
@@ -25,6 +25,7 @@ Imports:
     lubridate,
     methods,
     purrr,
+    R6,
     readr,
     rlang,
     snakecase,


### PR DESCRIPTION
R6 was used throughout the package (9x R6::R6Class()) but was not declared as a dependency in DESCRIPTION. Without R6 in Imports, R does not guarantee R6 is loaded before evaluating the package source files. This caused CohortPrevalenceExperiment and other R6 classes to be silently undefined when loading the package (e.g. on R 4.4), resulting in 'object not found' errors.

Also update RoxygenNote from 7.3.2 to 7.3.3.