### PR TITLE
fix: correct lookback condition in era SQL files

### DIFF
--- a/inst/sql/pd1_era.sql
+++ b/inst/sql/pd1_era.sql
@@ -38,8 +38,8 @@ DROP TABLE IF EXISTS #allEvents;
 CREATE TABLE #allEvents AS
 SELECT *,
   CASE WHEN 
-    cohort_start_date <= calendar_end_date
-    AND cohort_end_date >= DATEADD(day, -@lookback, calendar_start_date)
+    cohort_start_date <= calendar_start_date
+    AND cohort_start_date >= DATEADD(day, -@lookback, calendar_start_date)
   THEN 1 ELSE 0 END AS case_event
 FROM #denom
 ;

--- a/inst/sql/pd2_era.sql
+++ b/inst/sql/pd2_era.sql
@@ -38,7 +38,7 @@ CREATE TABLE #allEvents AS
 SELECT *,
   CASE WHEN 
     cohort_start_date <= calendar_end_date
-    AND cohort_end_date >= DATEADD(day, -@lookback, calendar_start_date)
+    AND cohort_start_date >= DATEADD(day, -@lookback, calendar_start_date)
   THEN 1 ELSE 0 END AS case_event
 FROM #denom
 ;

--- a/inst/sql/pd3_era.sql
+++ b/inst/sql/pd3_era.sql
@@ -33,7 +33,7 @@ CREATE TABLE #allEvents AS
 SELECT *,
   CASE WHEN 
     cohort_start_date <= calendar_end_date
-    AND cohort_end_date >= DATEADD(day, -@lookback, calendar_start_date)
+    AND cohort_start_date >= DATEADD(day, -@lookback, calendar_start_date)
   THEN 1 ELSE 0 END AS case_event
 FROM #denom
 ;

--- a/inst/sql/pd4_era.sql
+++ b/inst/sql/pd4_era.sql
@@ -38,7 +38,7 @@ CREATE TABLE #allEvents AS
 SELECT *,
   CASE WHEN 
     cohort_start_date <= calendar_end_date
-    AND cohort_end_date >= DATEADD(day, -@lookback, calendar_start_date)
+    AND cohort_start_date >= DATEADD(day, -@lookback, calendar_start_date)
   THEN 1 ELSE 0 END AS case_event
 FROM #denom
 ;


### PR DESCRIPTION
In pd1_era.sql, pd2_era.sql pd3_era.sql and pd4_era.sql the case_event condition used cohort_end_date to check the lookback window. This made the lookback parameter effectively infinite since any era overlapping the window (regardless of start date) was counted.

Fix: use cohort_start_date in both condition sides so only cases whose condition ERA started within the lookback window are counted.

pd1_era: also tighten upper bound from calendar_end_date to calendar_start_date (point prevalence semantics: condition must start on or before the first day of the POI).